### PR TITLE
Add npm publishing workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,22 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'package.json'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org/'
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This PR adds a GitHub workflow to automatically publish the package to npm when changes are pushed to main.\n\nThis will help ensure the package is published with the lowercase name `@jasondsmith72/cwm-api-gateway-mcp` to comply with npm naming conventions that don't allow uppercase letters in package names.\n\nAfter merging this PR, you should add an NPM_TOKEN secret to your repository settings with an npm token that has publish permissions.